### PR TITLE
Fixes various import problems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "saguaro-pipeline"
-version = "2.0.0"
+version = "2.0.1"
 readme = "README.md"
 license.file = "LICENSE"
 dynamic = ["dependencies"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ephem~=4.1.4
 matplotlib
 Pillow
 psycopg2~=2.9.6
+scikit-learn==0.22.1
 slackclient~=2.9.4
 tensorflow~=2.12.0
 watchdog

--- a/saguaro_pipeline/css.py
+++ b/saguaro_pipeline/css.py
@@ -17,7 +17,7 @@ from astropy.io import fits
 from astropy.utils.exceptions import AstropyWarning
 
 from . import saguaro_pipe
-from importlib.resources import files
+from importlib_resources import files
 
 warnings.simplefilter('ignore', category=AstropyWarning)
 gc.enable()

--- a/saguaro_pipeline/ingestion.py
+++ b/saguaro_pipeline/ingestion.py
@@ -10,7 +10,7 @@ from astropy.io import fits
 import numpy as np
 
 from . import newsql
-from importlib.resources import files
+from importlib_resources import files
 from tensorflow.keras import models
 
 

--- a/saguaro_pipeline/saguaro_pipe.py
+++ b/saguaro_pipeline/saguaro_pipe.py
@@ -28,7 +28,7 @@ import traceback
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 import fnmatch as fn
-import zogy
+from zogy import zogy
 from . import ingestion, saguaro_logging
 
 warnings.simplefilter('ignore', category=AstropyWarning)

--- a/saguaro_pipeline/saguaro_pipe.py
+++ b/saguaro_pipeline/saguaro_pipe.py
@@ -245,8 +245,6 @@ def action(item_list):
     reduced, comment = tel.science_process(file, unique_dir, log_file_name)  # submit image for reduction
     q.put(logger.info('Ending reduction for '+file+' '+comment))
     ref = tel.find_ref(reduced)  # find reference image
-    subprocess.call(['cp', '-r', zogy_path + '/' + C.cfg_dir, '.'])  # copy over needed zogy config files
-    q.put(logger.info('cp -r '+zogy_path+'/'+C.cfg_dir+' .'))
     try:
         if ref:  # submit as subtraction job
             q.put(logger.info("Reference found. Starting zogy subtraction for "+reduced))
@@ -313,11 +311,9 @@ def main(telescope=None, date=None, cpu=None):
         print('No telescope given, please give telescope and re-run.')
         sys.exit(-1)
     else:
-        global zogy_path, tel, C
-    zogy_path = os.environ['ZOGYHOME']
+        global tel
     try:
         tel = importlib.import_module(f'{__package__}.{telescope}')  # import telescope setting file
-        C = importlib.import_module('Settings.Constants_' + telescope)
     except ImportError:
         print('No such telescope file, please check that the file is in the same directory as the pipeline.')
         sys.exit(-1)

--- a/saguaro_pipeline/saguaro_pipe.py
+++ b/saguaro_pipeline/saguaro_pipe.py
@@ -99,7 +99,7 @@ def scheduled_exit(date, telescope):
     If the current time has past the scheduled exit time and before the
     scheduled start time, return True. Otherwise return False.
     """
-    tel = importlib.import_module(telescope)
+    tel = importlib.import_module(f'{__package__}.{telescope}')
     if (date + datetime.timedelta(hours=tel.time_zone())).hour == 8:
         # if current is after scheduled exit but before next run, exit
         return True
@@ -111,7 +111,7 @@ def mask_create(science_file, telescope, unique_dir, Red, mask_bp, header, comme
     """
     Creates a mask file for an image.
     """
-    tel = importlib.import_module(telescope)
+    tel = importlib.import_module(f'{__package__}.{telescope}')
     mask_infnan = ~np.isfinite(Red)
     mask_bp[mask_infnan & (mask_bp != 32)] = 1
     Red[mask_infnan] = 0
@@ -316,7 +316,7 @@ def main(telescope=None, date=None, cpu=None):
         global zogy_path, tel, C
     zogy_path = os.environ['ZOGYHOME']
     try:
-        tel = importlib.import_module(telescope)  # import telescope setting file
+        tel = importlib.import_module(f'{__package__}.{telescope}')  # import telescope setting file
         C = importlib.import_module('Settings.Constants_' + telescope)
     except ImportError:
         print('No such telescope file, please check that the file is in the same directory as the pipeline.')


### PR DESCRIPTION
* We forgot to add scikit-learn to the requirements, which is needed for the old machine learning model. We most recently used version 0.22.1 to create the model, so we are limited to Python 3.8.
* Because we're limited to Python 3.8, we have to use the standalone `importlib_resources` module instead of the Python 3.11 version of `importlib.resources`. Both are built in.
* Because of our new packaging, we have to import `zogy.zogy` and `saguaro_pipeline.css` instead of just the submodules.
* Version 0.64 of ZOGY removes the requirement to copy configuration files before running the subtraction.