### PR TITLE
fix a unit bug in the catalog coordinates

### DIFF
--- a/saguaro_pipeline/ingestion.py
+++ b/saguaro_pipeline/ingestion.py
@@ -97,8 +97,8 @@ def movingobjectfilter(s_catalog, s_ra, s_dec, obsmjd, filter_radius):
         body.compute(s_date)
         ras.append(body.a_ra)
         decs.append(body.a_dec)
-    catalog_coords = SkyCoord(ras, decs, unit='deg')
-    s_coords = SkyCoord(s_ra, s_dec)
+    catalog_coords = SkyCoord(ras, decs, unit='rad')
+    s_coords = SkyCoord(s_ra, s_dec, unit='deg')
     _, separation, _ = s_coords.match_to_catalog_sky(catalog_coords)
     return separation.arcsec < filter_radius
 


### PR DESCRIPTION
When adding the catalog coordinates they are in radians, not degrees. I just fixed this issue.