### PR TITLE
use new public permission from tomtoolkit 2.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "saguaro-pipeline"
-version = "2.2.1"
+version = "2.3.0"
 readme = "README.md"
 license.file = "LICENSE"
 dynamic = ["dependencies"]

--- a/saguaro_pipeline/css.py
+++ b/saguaro_pipeline/css.py
@@ -4,7 +4,7 @@
 Telescope setting file for CSS 1.5m Mt Lemmon telescope.
 """
 
-__version__ = "2.2.1"  # last updated 2024-11-04
+__version__ = "2.3.0"  # last updated 2025-05-29
 
 import datetime
 import gc

--- a/saguaro_pipeline/median_watcher.py
+++ b/saguaro_pipeline/median_watcher.py
@@ -4,7 +4,7 @@
 Script to create median images from the 4 CSS images per field.
 """
 
-__version__ = "2.2.1"  # last updated 2024-11-04
+__version__ = "2.3.0"  # last updated 2025-05-29
 
 import argparse
 import numpy as np

--- a/saguaro_pipeline/newsql.py
+++ b/saguaro_pipeline/newsql.py
@@ -52,21 +52,14 @@ def get_or_create_targets(ra, dec, radius=2.):
         names_to_add = 'J' + np.char.array(coord.ra.to_string('hourangle', sep='', precision=2, pad=True)) \
                            + np.char.array(coord.dec.to_string('deg', sep='', precision=1, pad=True, alwayssign=True))
         names_to_add = np.char.replace(names_to_add, '.', '')
-        values_to_add = ', '.join([f"('{name}', 'SIDEREAL', NOW(), NOW(), {alpha:f}, {delta:f}, 2000, '')"
+        values_to_add = ', '.join([f"('{name}', 'SIDEREAL', NOW(), NOW(), 'PUBLIC', {alpha:f}, {delta:f}, 2000, '')"
                                    for name, alpha, delta in zip(names_to_add, ra_to_add, dec_to_add)])
         query = f"""
-        INSERT INTO tom_targets_basetarget (name, type, created, modified, ra, dec, epoch, scheme)
+        INSERT INTO tom_targets_basetarget (name, type, created, modified, permissions, ra, dec, epoch, scheme)
         VALUES {values_to_add} RETURNING id;
         """
         res = db.queryfetchall(query)
         target_ids[no_match] = res['id']
-
-        values_to_add = ', '.join([f"({tid}, 14, 1, 55), ({tid}, 14, 1, 56), ({tid}, 14, 1, 57)" for tid in res['id']])
-        query = f"""
-        INSERT INTO guardian_groupobjectpermission (object_pk, content_type_id, group_id, permission_id)
-        VALUES {values_to_add};
-        """
-        db.query(query)
 
     db.commit()
     db.close()

--- a/saguaro_pipeline/saguaro_pipe.py
+++ b/saguaro_pipeline/saguaro_pipe.py
@@ -4,7 +4,7 @@
 Pipeline for real-time data reduction and image subtraction.
 """
 
-__version__ = "2.2.1"  # last updated 2024-11-04
+__version__ = "2.3.0"  # last updated 2025-05-29
 
 import argparse
 import datetime


### PR DESCRIPTION
Set newly created targets to PUBLIC using the new public permission from the TOM Toolkit v2.24.0. Merge only after https://github.com/SAGUARO-MMA/saguaro_tom/pull/125.