### PR TITLE
Switch to new Slack SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "saguaro-pipeline"
-version = "2.3.0"
+version = "2.3.1"
 readme = "README.md"
 license.file = "LICENSE"
 dynamic = ["dependencies"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ matplotlib
 Pillow
 psycopg2~=2.9.6
 scikit-learn==0.22.1
-slackclient~=2.9.4
+slack_sdk==3.35.0
 tensorflow~=2.12.0
 watchdog
 zogy @ git+https://github.com/KerryPaterson/ZOGY

--- a/saguaro_pipeline/css.py
+++ b/saguaro_pipeline/css.py
@@ -4,7 +4,7 @@
 Telescope setting file for CSS 1.5m Mt Lemmon telescope.
 """
 
-__version__ = "2.3.0"  # last updated 2025-05-29
+__version__ = "2.3.1"  # last updated 2025-05-30
 
 import datetime
 import gc

--- a/saguaro_pipeline/median_watcher.py
+++ b/saguaro_pipeline/median_watcher.py
@@ -4,7 +4,7 @@
 Script to create median images from the 4 CSS images per field.
 """
 
-__version__ = "2.3.0"  # last updated 2025-05-29
+__version__ = "2.3.1"  # last updated 2025-05-30
 
 import argparse
 import numpy as np

--- a/saguaro_pipeline/saguaro_logging.py
+++ b/saguaro_pipeline/saguaro_logging.py
@@ -3,8 +3,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-from slack import WebClient
-from slack.errors import SlackApiError
+from slack_sdk import WebClient
 import logging
 import os
 
@@ -37,9 +36,9 @@ class MyLogger(object):
         """
         self._log.critical(text)
         try:
-            self.slack_client.chat_postMessage(channel='pipeline', text=text)
+            self.slack_client.chat_postMessage(channel='CDY2K2F9V', text=text)
         except:  # if connection error occurs, add to log
-            self._log.error('Connection error: failed to connect to slack. Above meassage not uploaded.')
+            self._log.error('Connection error: failed to connect to slack. Above message not uploaded.')
 
     @staticmethod
     def shutdown():

--- a/saguaro_pipeline/saguaro_pipe.py
+++ b/saguaro_pipeline/saguaro_pipe.py
@@ -419,7 +419,7 @@ def main(telescope=None, date=None, cpu=None):
             plt.xlabel('Number of candidates per field')
             hist_file_name = log_file_name + '.pdf'
             plt.savefig(hist_file_name)
-            logger.slack_client.files_upload(channels='pipeline', file=hist_file_name)
+            logger.slack_client.files_upload_v2(channel='CDY2K2F9V', file=hist_file_name)
 
         logger.shutdown()
         sys.exit()

--- a/saguaro_pipeline/saguaro_pipe.py
+++ b/saguaro_pipeline/saguaro_pipe.py
@@ -4,7 +4,7 @@
 Pipeline for real-time data reduction and image subtraction.
 """
 
-__version__ = "2.3.0"  # last updated 2025-05-29
+__version__ = "2.3.1"  # last updated 2025-05-30
 
 import argparse
 import datetime


### PR DESCRIPTION
This switches the pipeline's Slack log messages to use the new Slack SDK. The old `slackclient` package is deprecated along with legacy Slack apps.